### PR TITLE
Correct bug in channel dimensions

### DIFF
--- a/src/main/java/plugins/tinevez/imglib2icy/VirtualSequence.java
+++ b/src/main/java/plugins/tinevez/imglib2icy/VirtualSequence.java
@@ -30,7 +30,7 @@ public class VirtualSequence extends Sequence
 	public enum DimensionArrangement
 	{
 		XY( false, false, false, 0, 0, 0, 0, 0 ),
-		XYC( true, false, false, 0, 0, 0, 0, 0 ),
+		XYC( true, false, false, 2, 0, 0, 0, 0 ),
 		XYZ( false, true, false, 0, 2, 2, 0, 0 ),
 		XYT( false, false, true, 0, 0, 0, 2, 2 ),
 		XYCT( true, false, true, 2, 0, 0, 3, 2 ),


### PR DESCRIPTION
The Virtual sequence is not defining the position of the dimension Channel, even though it is required